### PR TITLE
Fix a parameter error when copying from readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ view file: **views.py**
 
         # Provide Paginator with the request object for complete querystring generation
 
-        p = Paginator(objects, request=request)
+        p = Paginator(objects, request=request, per_page=2)
 
         people = p.page(page)
 


### PR DESCRIPTION
The paginator object also needs the number of elements per pages.
Otherwise we get this error : 
     TypeError: **init**() takes at least 3 arguments (3 given)
